### PR TITLE
Storage permission

### DIFF
--- a/demo/src/main/AndroidManifest.xml
+++ b/demo/src/main/AndroidManifest.xml
@@ -14,7 +14,7 @@
 <manifest package="com.google.android.cameraview.demo"
           xmlns:android="http://schemas.android.com/apk/res/android">
 
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="18"/>
     <uses-permission android:name="android.permission.CAMERA"/>
     <uses-feature android:name="android.hardware.camera" />
     <uses-feature android:name="android.hardware.camera.autofocus" />

--- a/demo/src/main/java/com/google/android/cameraview/demo/MainActivity.java
+++ b/demo/src/main/java/com/google/android/cameraview/demo/MainActivity.java
@@ -55,7 +55,6 @@ public class MainActivity extends AppCompatActivity implements
     private static final String TAG = "MainActivity";
 
     private static final int REQUEST_CAMERA_PERMISSION = 1;
-    private static final int REQUEST_STORAGE_PERMISSION = 2;
 
     private static final String FRAGMENT_DIALOG = "dialog";
 
@@ -88,24 +87,8 @@ public class MainActivity extends AppCompatActivity implements
         public void onClick(View v) {
             switch (v.getId()) {
                 case R.id.take_picture:
-                    if (ContextCompat.checkSelfPermission(MainActivity.this,
-                            Manifest.permission.WRITE_EXTERNAL_STORAGE)
-                            == PackageManager.PERMISSION_GRANTED) {
-                        if (mCameraView != null) {
-                            mCameraView.takePicture();
-                        }
-                    } else if (ActivityCompat.shouldShowRequestPermissionRationale(
-                            MainActivity.this, Manifest.permission.WRITE_EXTERNAL_STORAGE)) {
-                        ConfirmationDialogFragment
-                                .newInstance(R.string.storage_permission_confirmation,
-                                        new String[]{Manifest.permission.WRITE_EXTERNAL_STORAGE},
-                                        REQUEST_STORAGE_PERMISSION,
-                                        R.string.storage_permission_not_granted)
-                                .show(getSupportFragmentManager(), FRAGMENT_DIALOG);
-                    } else {
-                        ActivityCompat.requestPermissions(MainActivity.this,
-                                new String[]{Manifest.permission.WRITE_EXTERNAL_STORAGE},
-                                REQUEST_STORAGE_PERMISSION);
+                    if (mCameraView != null) {
+                        mCameraView.takePicture();
                     }
                     break;
             }
@@ -184,15 +167,6 @@ public class MainActivity extends AppCompatActivity implements
                             Toast.LENGTH_SHORT).show();
                 }
                 // No need to start camera here; it is handled by onResume
-                break;
-            case REQUEST_STORAGE_PERMISSION:
-                if (permissions.length != 1 || grantResults.length != 1) {
-                    throw new RuntimeException("Error on requesting storage permission.");
-                }
-                if (grantResults[0] != PackageManager.PERMISSION_GRANTED) {
-                    Toast.makeText(this, R.string.storage_permission_not_granted,
-                            Toast.LENGTH_SHORT).show();
-                }
                 break;
         }
     }

--- a/demo/src/main/res/values/strings.xml
+++ b/demo/src/main/res/values/strings.xml
@@ -15,8 +15,6 @@
     <string name="app_name">CameraView Demo</string>
     <string name="camera_permission_confirmation">This app demonstrates the usage of CameraView. In order to do that, it needs permission to access camera.</string>
     <string name="camera_permission_not_granted">Camera app cannot do anything without camera permission.</string>
-    <string name="storage_permission_confirmation">This app saves taken photos to external storage.</string>
-    <string name="storage_permission_not_granted">The app does not have permission to save a photo.</string>
     <string name="picture_taken">Picture taken</string>
     <string name="switch_flash">Switch flash</string>
     <string name="switch_camera">Switch camera</string>


### PR DESCRIPTION
The `getExternalFilesDir()` directory does not require the `WRITE_EXTERNAL_STORAGE` permission as of API 19. The permission can be limited to API 18 and below, and the code to request the permission can be removed altogether because run-time permissions are not a thing on API 18 and below.

Resolves #2 