### PR TITLE
Fixes crash after accepting permission dialog

### DIFF
--- a/library/src/main/api21/com/google/android/cameraview/Camera2.java
+++ b/library/src/main/api21/com/google/android/cameraview/Camera2.java
@@ -97,7 +97,9 @@ class Camera2 extends CameraViewImpl {
             try {
                 mCaptureSession.setRepeatingRequest(mPreviewRequestBuilder.build(),
                         mCaptureCallback, null);
-            } catch (CameraAccessException | IllegalStateException e) {
+            } catch (CameraAccessException e) {
+                Log.e(TAG, "Failed to start camera preview because it couldn't access camera", e);
+            } catch (IllegalStateException e) {
                 Log.e(TAG, "Failed to start camera preview.", e);
             }
         }

--- a/library/src/main/api21/com/google/android/cameraview/Camera2.java
+++ b/library/src/main/api21/com/google/android/cameraview/Camera2.java
@@ -97,7 +97,7 @@ class Camera2 extends CameraViewImpl {
             try {
                 mCaptureSession.setRepeatingRequest(mPreviewRequestBuilder.build(),
                         mCaptureCallback, null);
-            } catch (CameraAccessException e) {
+            } catch (CameraAccessException | IllegalStateException e) {
                 Log.e(TAG, "Failed to start camera preview.", e);
             }
         }
@@ -109,7 +109,9 @@ class Camera2 extends CameraViewImpl {
 
         @Override
         public void onClosed(@NonNull CameraCaptureSession session) {
-            mCaptureSession = null;
+            if (mCaptureSession != null && mCaptureSession.equals(session)) {
+                mCaptureSession = null;
+            }
         }
 
     };


### PR DESCRIPTION
For some reason, after the permission dialog is accepted, there are two `CameraCaptureSession` opening at the same time, causing an `IllegalStateException`. This fix catches the exception so the second time that `onConfigured()` is called, the capture session is set up successfully. 

It also makes sure that the field `mCaptureSession` is not cleared incorrectly during `onClosed()`