### PR TITLE
adjust image size to fit current view

### DIFF
--- a/demo/src/main/res/layout/activity_main.xml
+++ b/demo/src/main/res/layout/activity_main.xml
@@ -17,12 +17,13 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical"
+    android:gravity="center_horizontal"
     tools:context=".MainActivity">
 
     <include
         layout="@layout/include_camera"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"/>
+        android:layout_width="300dp"
+        android:layout_height="300dp"/>
 
     <include
         layout="@layout/include_control"


### PR DESCRIPTION
When I use a fixed size for the CameraView like in the first picture, i realised the size of the saved photo differs from the displayed in the app

I came up with a fix to crop the image to only save the portion of the picture the user is really watching in the app. The comparison of the previous saved image and the cropped is show below.

![image](https://cloud.githubusercontent.com/assets/4575788/19737291/79342d4c-9b78-11e6-8f4c-3036fc56214a.png)

![image](https://cloud.githubusercontent.com/assets/4575788/19737187/0a628210-9b78-11e6-97ba-caf475612f0a.png)
