### PR TITLE
Fix preview centering

### DIFF
--- a/library/src/main/res/layout-v14/texture_view.xml
+++ b/library/src/main/res/layout-v14/texture_view.xml
@@ -16,6 +16,8 @@
     <TextureView
         android:id="@+id/texture_view"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"/>
+        android:layout_height="match_parent"
+        android:gravity="center"
+        />
 
 </merge>

--- a/library/src/main/res/layout/surface_view.xml
+++ b/library/src/main/res/layout/surface_view.xml
@@ -16,6 +16,8 @@
     <SurfaceView
         android:id="@+id/surface_view"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"/>
+        android:layout_height="match_parent"
+        android:gravity="center"
+        />
 
 </merge>


### PR DESCRIPTION
Since preview hosted in framelayout is not centered result picture is shifted to the left, because default gravity is left|top