### PR TITLE
Select better camera focus view when setting autofocus = true

### DIFF
--- a/library/src/main/api14/com/google/android/cameraview/Camera1.java
+++ b/library/src/main/api14/com/google/android/cameraview/Camera1.java
@@ -386,6 +386,10 @@ class Camera1 extends CameraViewImpl {
             final List<String> modes = mCameraParameters.getSupportedFocusModes();
             if (autoFocus && modes.contains(Camera.Parameters.FOCUS_MODE_CONTINUOUS_PICTURE)) {
                 mCameraParameters.setFocusMode(Camera.Parameters.FOCUS_MODE_CONTINUOUS_PICTURE);
+            } else if (autoFocus && modes.contains(Camera.Parameters.FOCUS_MODE_CONTINUOUS_VIDEO)) {
+                mCameraParameters.setFocusMode(Camera.Parameters.FOCUS_MODE_CONTINUOUS_VIDEO);
+            } else if (autoFocus && modes.contains(Camera.Parameters.FOCUS_MODE_AUTO)) {
+                mCameraParameters.setFocusMode(Camera.Parameters.FOCUS_MODE_AUTO);
             } else if (modes.contains(Camera.Parameters.FOCUS_MODE_FIXED)) {
                 mCameraParameters.setFocusMode(Camera.Parameters.FOCUS_MODE_FIXED);
             } else if (modes.contains(Camera.Parameters.FOCUS_MODE_INFINITY)) {


### PR DESCRIPTION
Not all devices support `FOCUS_MODE_CONTINUOUS_PICTURE` (e.g. HTC Desire supports only `FOCUS_MODE_AUTO` and `FOCUS_MODE_INFINITY`). I believe `FOCUS_MODE_AUTO` should be treated as autoFocus = true, same to `FOCUS_MODE_CONTINUOUS_VIDEO`.