### PR TITLE
Fix: Cannot process multiple parallel `takePicture`. Need to wait for…

### DIFF
--- a/library/src/main/api14/com/google/android/cameraview/Camera1.java
+++ b/library/src/main/api14/com/google/android/cameraview/Camera1.java
@@ -27,6 +27,8 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Set;
 import java.util.SortedSet;
+import java.util.concurrent.atomic.AtomicBoolean;
+
 
 @SuppressWarnings("deprecation")
 class Camera1 extends CameraViewImpl {
@@ -44,6 +46,8 @@ class Camera1 extends CameraViewImpl {
     }
 
     private int mCameraId;
+
+    private final AtomicBoolean isPictureCaptureInProgress = new AtomicBoolean(false);
 
     Camera mCamera;
 
@@ -227,14 +231,17 @@ class Camera1 extends CameraViewImpl {
     }
 
     void takePictureInternal() {
-        mCamera.takePicture(null, null, null, new Camera.PictureCallback() {
-            @Override
-            public void onPictureTaken(byte[] data, Camera camera) {
-                mCallback.onPictureTaken(data);
-                camera.cancelAutoFocus();
-                camera.startPreview();
-            }
-        });
+        if (!isPictureCaptureInProgress.getAndSet(true)) {
+            mCamera.takePicture(null, null, null, new Camera.PictureCallback() {
+                @Override
+                public void onPictureTaken(byte[] data, Camera camera) {
+                    isPictureCaptureInProgress.set(false);
+                    mCallback.onPictureTaken(data);
+                    camera.cancelAutoFocus();
+                    camera.startPreview();
+                }
+            });
+        }
     }
 
     @Override


### PR DESCRIPTION
… on request to finish first.

Prev to this change, Samsung Galaxy S4 crashes in demo app due to this error:
```
[CAM-BACK]-ERR(virtual android::status_t android::ExynosCameraHWImpl::takePicture()):capture already in progress
java.lang.RuntimeException: takePicture failed
  at android.hardware.Camera.native_takePicture(Native Method)
  at android.hardware.Camera.takePicture(Camera.java:1338)
  at com.google.android.cameraview.Camera1.takePictureInternal(Unknown Source)
  at com.google.android.cameraview.Camera1$2.onAutoFocus(Unknown Source)
```