### PR TITLE
Expose a callback when no cameras are detected.

### DIFF
--- a/demo/src/main/java/com/google/android/cameraview/demo/MainActivity.java
+++ b/demo/src/main/java/com/google/android/cameraview/demo/MainActivity.java
@@ -245,6 +245,13 @@ public class MainActivity extends AppCompatActivity implements
         }
 
         @Override
+        public void onCameraNotAvailable(CameraView cameraView) {
+            Log.d(TAG, "onCameraNotAvailable");
+            Toast.makeText(cameraView.getContext(), R.string.camera_not_available,
+                    Toast.LENGTH_LONG).show();
+        }
+
+        @Override
         public void onPictureTaken(CameraView cameraView, final byte[] data) {
             Log.d(TAG, "onPictureTaken " + data.length);
             Toast.makeText(cameraView.getContext(), R.string.picture_taken, Toast.LENGTH_SHORT)

--- a/demo/src/main/res/values/strings.xml
+++ b/demo/src/main/res/values/strings.xml
@@ -22,4 +22,5 @@
     <string name="flash_auto">Flash auto</string>
     <string name="flash_off">Flash off</string>
     <string name="flash_on">Flash on</string>
+    <string name="camera_not_available">There are no cameras available.</string>
 </resources>

--- a/library/src/main/api14/com/google/android/cameraview/Camera1.java
+++ b/library/src/main/api14/com/google/android/cameraview/Camera1.java
@@ -83,7 +83,10 @@ class Camera1 extends CameraViewImpl {
     @Override
     boolean start() {
         chooseCamera();
-        openCamera();
+        if (!openCamera()) {
+            return false;
+        }
+
         if (mPreview.isReady()) {
             setUpPreview();
         }
@@ -272,10 +275,17 @@ class Camera1 extends CameraViewImpl {
         mCameraId = INVALID_CAMERA_ID;
     }
 
-    private void openCamera() {
+    private boolean openCamera() {
         if (mCamera != null) {
             releaseCamera();
         }
+
+        mCamera = null;
+        if (mCameraId == INVALID_CAMERA_ID) {
+            mCallback.onCameraNotAvailable();
+            return false;
+        }
+
         mCamera = Camera.open(mCameraId);
         mCameraParameters = mCamera.getParameters();
         // Supported preview sizes
@@ -295,6 +305,7 @@ class Camera1 extends CameraViewImpl {
         adjustCameraParameters();
         mCamera.setDisplayOrientation(calcCameraRotation(mDisplayOrientation));
         mCallback.onCameraOpened();
+        return true;
     }
 
     private AspectRatio chooseAspectRatio() {

--- a/library/src/main/api21/com/google/android/cameraview/Camera2.java
+++ b/library/src/main/api21/com/google/android/cameraview/Camera2.java
@@ -345,8 +345,12 @@ class Camera2 extends CameraViewImpl {
             int internalFacing = INTERNAL_FACINGS.get(mFacing);
             final String[] ids = mCameraManager.getCameraIdList();
             if (ids.length == 0) { // No camera
-                throw new RuntimeException("No camera available.");
+                mCameraId = null;
+                Log.e(TAG, "No camera devices present.");
+                mCallback.onCameraNotAvailable();
+                return false;
             }
+
             for (String id : ids) {
                 CameraCharacteristics characteristics = mCameraManager.getCameraCharacteristics(id);
                 Integer level = characteristics.get(
@@ -434,9 +438,13 @@ class Camera2 extends CameraViewImpl {
      * <p>The result will be processed in {@link #mCameraDeviceCallback}.</p>
      */
     private void startOpeningCamera() {
+        if (mCameraId == null) {
+            return;
+        }
+
         try {
             mCameraManager.openCamera(mCameraId, mCameraDeviceCallback, null);
-        } catch (CameraAccessException e) {
+        } catch (SecurityException|CameraAccessException e) {
             throw new RuntimeException("Failed to open camera: " + mCameraId, e);
         }
     }

--- a/library/src/main/base/com/google/android/cameraview/CameraViewImpl.java
+++ b/library/src/main/base/com/google/android/cameraview/CameraViewImpl.java
@@ -75,6 +75,8 @@ abstract class CameraViewImpl {
 
         void onCameraClosed();
 
+        void onCameraNotAvailable();
+
         void onPictureTaken(byte[] data);
 
     }

--- a/library/src/main/java/com/google/android/cameraview/CameraView.java
+++ b/library/src/main/java/com/google/android/cameraview/CameraView.java
@@ -429,6 +429,13 @@ public class CameraView extends FrameLayout {
         }
 
         @Override
+        public void onCameraNotAvailable() {
+            for (Callback callback : mCallbacks) {
+                callback.onCameraNotAvailable(CameraView.this);
+            }
+        }
+
+        @Override
         public void onPictureTaken(byte[] data) {
             for (Callback callback : mCallbacks) {
                 callback.onPictureTaken(CameraView.this, data);
@@ -511,6 +518,14 @@ public class CameraView extends FrameLayout {
          * @param cameraView The associated {@link CameraView}.
          */
         public void onCameraClosed(CameraView cameraView) {
+        }
+
+        /**
+         * Called when there is no camera to open
+         *
+         * @param cameraView The associated {@link CameraView}.
+         */
+        public void onCameraNotAvailable(CameraView cameraView) {
         }
 
         /**


### PR DESCRIPTION
Instead of throwing a Runtime exception, this patch exposes a callback to indicate there were no cameras enumerated.  Tested using emulator.