### PR TITLE
Camera2: Fail gracefully if an exception occurs within a callback

### DIFF
--- a/library/src/main/api21/com/google/android/cameraview/Camera2.java
+++ b/library/src/main/api21/com/google/android/cameraview/Camera2.java
@@ -61,7 +61,11 @@ class Camera2 extends CameraViewImpl {
         public void onOpened(@NonNull CameraDevice camera) {
             mCamera = camera;
             mCallback.onCameraOpened();
-            startCaptureSession();
+            try {
+                startCaptureSession();
+            } catch (CameraAccessException e) {
+                Log.e(TAG, "Failed to start camera session", e);
+            }
         }
 
         @Override
@@ -191,7 +195,11 @@ class Camera2 extends CameraViewImpl {
         mPreview.setCallback(new PreviewImpl.Callback() {
             @Override
             public void onSurfaceChanged() {
-                startCaptureSession();
+                try {
+                    startCaptureSession();
+                } catch (CameraAccessException e) {
+                    Log.e(TAG, "Failed to start camera session", e);
+                }
             }
         });
     }
@@ -261,7 +269,11 @@ class Camera2 extends CameraViewImpl {
         if (mCaptureSession != null) {
             mCaptureSession.close();
             mCaptureSession = null;
-            startCaptureSession();
+            try {
+                startCaptureSession();
+            } catch (CameraAccessException e) {
+                Log.e(TAG, "Failed to start camera session", e);
+            }
         }
         return true;
     }
@@ -433,6 +445,7 @@ class Camera2 extends CameraViewImpl {
      * <p>Starts opening a camera device.</p>
      * <p>The result will be processed in {@link #mCameraDeviceCallback}.</p>
      */
+    @SuppressWarnings("MissingPermission")
     private void startOpeningCamera() {
         try {
             mCameraManager.openCamera(mCameraId, mCameraDeviceCallback, null);
@@ -445,22 +458,20 @@ class Camera2 extends CameraViewImpl {
      * <p>Starts a capture session for camera preview.</p>
      * <p>This rewrites {@link #mPreviewRequestBuilder}.</p>
      * <p>The result will be continuously processed in {@link #mSessionCallback}.</p>
+     *
+     * @throws CameraAccessException exceptions from {@link Camera2}
      */
-    void startCaptureSession() {
+    void startCaptureSession() throws CameraAccessException {
         if (!isCameraOpened() || !mPreview.isReady() || mImageReader == null) {
             return;
         }
         Size previewSize = chooseOptimalSize();
         mPreview.setBufferSize(previewSize.getWidth(), previewSize.getHeight());
         Surface surface = mPreview.getSurface();
-        try {
-            mPreviewRequestBuilder = mCamera.createCaptureRequest(CameraDevice.TEMPLATE_PREVIEW);
-            mPreviewRequestBuilder.addTarget(surface);
-            mCamera.createCaptureSession(Arrays.asList(surface, mImageReader.getSurface()),
-                    mSessionCallback, null);
-        } catch (CameraAccessException e) {
-            throw new RuntimeException("Failed to start camera session");
-        }
+        mPreviewRequestBuilder = mCamera.createCaptureRequest(CameraDevice.TEMPLATE_PREVIEW);
+        mPreviewRequestBuilder.addTarget(surface);
+        mCamera.createCaptureSession(Arrays.asList(surface, mImageReader.getSurface()),
+                mSessionCallback, null);
     }
 
     /**


### PR DESCRIPTION
This change should prevent hard crashes when we can't load cameraview.

Before: app crashes if these exception occur
This occurred while I was testing out cameraview and then created an intent to load the camera. When the intent came back and `onResume()` was called (which then called `cameraview.start()` the sample app would hard crash.

This prevents a hard crash but still leaves the cameraview in a broken state.

Was tested using https://github.com/lytefast/flex-input + `Google Pixel` Phone:
0) disable the google pixel from the blacklist in CameraFragment#isBlacklistedDevice()
1) load app
2) hit `(+)` button
3) go to camera
4) hit the right button to open the camera app
5) capture picture

Result: app hard crashes
With change: picture is captured, cameraview is broken, but the app is still running correctly.