### PR TITLE
Issue #107 - mAutoFocus should not be modified here as it affects the…

### DIFF
--- a/library/src/main/api21/com/google/android/cameraview/Camera2.java
+++ b/library/src/main/api21/com/google/android/cameraview/Camera2.java
@@ -500,7 +500,6 @@ class Camera2 extends CameraViewImpl {
             // Auto focus is not supported
             if (modes == null || modes.length == 0 ||
                     (modes.length == 1 && modes[0] == CameraCharacteristics.CONTROL_AF_MODE_OFF)) {
-                mAutoFocus = false;
                 mPreviewRequestBuilder.set(CaptureRequest.CONTROL_AF_MODE,
                         CaptureRequest.CONTROL_AF_MODE_OFF);
             } else {


### PR DESCRIPTION
… preference set in the xml.  If one of two cameras does not support auto-focus, and you set mAutoFocus to false here, then when you switch back to the camera that DOES support auto-focus, the auto-focus feature will never be activated, even though it is set to true in the xml, because mAutoFocus has been manually set to false here.