### PR TITLE
Fix preview size issue. It is now below or equal to the 1080p Camera2 guarantee

### DIFF
--- a/library/src/main/api21/com/google/android/cameraview/Camera2.java
+++ b/library/src/main/api21/com/google/android/cameraview/Camera2.java
@@ -39,6 +39,7 @@ import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.Set;
 import java.util.SortedSet;
+import java.util.TreeSet;
 
 @TargetApi(21)
 class Camera2 extends CameraViewImpl {
@@ -51,6 +52,16 @@ class Camera2 extends CameraViewImpl {
         INTERNAL_FACINGS.put(Constants.FACING_BACK, CameraCharacteristics.LENS_FACING_BACK);
         INTERNAL_FACINGS.put(Constants.FACING_FRONT, CameraCharacteristics.LENS_FACING_FRONT);
     }
+
+    /**
+     * Max preview width that is guaranteed by Camera2 API
+     */
+    private static final int MAX_PREVIEW_WIDTH = 1920;
+
+    /**
+     * Max preview height that is guaranteed by Camera2 API
+     */
+    private static final int MAX_PREVIEW_HEIGHT = 1080;
 
     private final CameraManager mCameraManager;
 
@@ -479,15 +490,24 @@ class Camera2 extends CameraViewImpl {
             surfaceLonger = surfaceWidth;
             surfaceShorter = surfaceHeight;
         }
-        SortedSet<Size> candidates = mPreviewSizes.sizes(mAspectRatio);
-        // Pick the smallest of those big enough.
-        for (Size size : candidates) {
+        SortedSet<Size> allCandidates = mPreviewSizes.sizes(mAspectRatio);
+
+        // Eliminate candidates that are bigger than Camera2 PREVIEW guarantees
+        SortedSet<Size> guaranteedCandidates = new TreeSet<>();
+        for (Size size: allCandidates) {
+            if (size.getWidth() <= MAX_PREVIEW_WIDTH && size.getHeight() <= MAX_PREVIEW_HEIGHT) {
+                guaranteedCandidates.add(size);
+            }
+        }
+
+        // Pick the smallest of those big enough
+        for (Size size : guaranteedCandidates) {
             if (size.getWidth() >= surfaceLonger && size.getHeight() >= surfaceShorter) {
                 return size;
             }
         }
         // If no size is big enough, pick the largest one.
-        return candidates.last();
+        return guaranteedCandidates.last();
     }
 
     /**

--- a/library/src/main/java/com/google/android/cameraview/CameraView.java
+++ b/library/src/main/java/com/google/android/cameraview/CameraView.java
@@ -88,6 +88,11 @@ public class CameraView extends FrameLayout {
     @SuppressWarnings("WrongConstant")
     public CameraView(Context context, AttributeSet attrs, int defStyleAttr) {
         super(context, attrs, defStyleAttr);
+        if (isInEditMode()){
+            mCallbacks = null;
+            mDisplayOrientationDetector = null;
+            return;
+        }
         // Internal setup
         final PreviewImpl preview = createPreviewImpl(context);
         mCallbacks = new CallbackBridge();
@@ -135,17 +140,25 @@ public class CameraView extends FrameLayout {
     @Override
     protected void onAttachedToWindow() {
         super.onAttachedToWindow();
-        mDisplayOrientationDetector.enable(ViewCompat2.getDisplay(this));
+        if (!isInEditMode()) {
+            mDisplayOrientationDetector.enable(ViewCompat2.getDisplay(this));
+        }
     }
 
     @Override
     protected void onDetachedFromWindow() {
-        mDisplayOrientationDetector.disable();
+        if (!isInEditMode()) {
+            mDisplayOrientationDetector.disable();
+        }
         super.onDetachedFromWindow();
     }
 
     @Override
     protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
+        if (isInEditMode()){
+            super.onMeasure(widthMeasureSpec, heightMeasureSpec);
+            return;
+        }
         // Handle android:adjustViewBounds
         if (mAdjustViewBounds) {
             if (!isCameraOpened()) {


### PR DESCRIPTION
Taking maximum preview size example from [Camera2Basic](https://github.com/googlesamples/android-Camera2Basic/blob/master/Application/src/main/java/com/example/android/camera2basic/Camera2BasicFragment.java#L384)

The motivation is from the [official docs](https://developer.android.com/reference/android/hardware/camera2/CameraDevice.html) where it states that 
> For the maximum size column, PREVIEW refers to the best size match to the device's screen resolution, or to 1080p (1920x1080), whichever is smaller

This might fix #63 - as this is the same error behaviour that lead us to implementing this fix.

Also, while using the view in Android Studio, the Preview renderer keeps giving errors about this view, as described in #31 - so I added a few `isInEditMode()`  checks to skip using android services like camera or orientation sensor.
