### PR TITLE
fix crash (Issue #11)

### DIFF
--- a/library/src/main/api21/com/google/android/cameraview/Camera2.java
+++ b/library/src/main/api21/com/google/android/cameraview/Camera2.java
@@ -98,7 +98,7 @@ class Camera2 extends CameraViewImpl {
 
         @Override
         public void onConfigured(@NonNull CameraCaptureSession session) {
-            if (mCamera == null) {
+            if (!isCameraOpened()) {
                 return;
             }
             mCaptureSession = session;
@@ -202,7 +202,7 @@ class Camera2 extends CameraViewImpl {
         mPreview.setCallback(new PreviewImpl.Callback() {
             @Override
             public void onSurfaceChanged() {
-                startCaptureSession();
+                restartCaptureSession();
             }
         });
     }
@@ -224,7 +224,7 @@ class Camera2 extends CameraViewImpl {
             mCaptureSession.close();
             mCaptureSession = null;
         }
-        if (mCamera != null) {
+        if (isCameraOpened()) {
             mCamera.close();
             mCamera = null;
         }
@@ -269,12 +269,16 @@ class Camera2 extends CameraViewImpl {
             return false;
         }
         mAspectRatio = ratio;
+        restartCaptureSession();
+        return true;
+    }
+
+    private void restartCaptureSession() {
         if (mCaptureSession != null) {
             mCaptureSession.close();
             mCaptureSession = null;
             startCaptureSession();
         }
-        return true;
     }
 
     @Override


### PR DESCRIPTION
`PreviewImpl.Callback.onSurfaceChanged()` assumes that the camera has been initialized and started properly.   However, there is no check for this when `startCaptureSession()` is called by `onSurfaceChanged()`. 
In particular,  on first launch after install, the OS permissions dialog appears, which prevents `startCaptureSession()` from starting normally (from` Camera2.start()` ).  This invalidates the original assumption; which leads to the IllegalStateException due to  the camera not being started properly.

The fix is to guarantee that `startCaptureSession()` is not called prematurely until the camera has been properly started. 

This fixes issue #11 