### PR TITLE
Expose certain camera parameters

### DIFF
--- a/library/src/androidTest/java/com/google/android/cameraview/CameraViewTest.java
+++ b/library/src/androidTest/java/com/google/android/cameraview/CameraViewTest.java
@@ -29,6 +29,9 @@ import static com.google.android.cameraview.CameraViewActions.setAspectRatio;
 import static com.google.android.cameraview.CameraViewMatchers.hasAspectRatio;
 
 import static junit.framework.Assert.assertFalse;
+import static junit.framework.Assert.assertNotNull;
+import static junit.framework.Assert.assertNotSame;
+import static junit.framework.Assert.assertTrue;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.hasItem;
@@ -243,6 +246,24 @@ public class CameraViewTest {
         }
     }
 
+    @Test
+    public void testGetFOV() {
+        final CameraView cameraView = (CameraView) rule.getActivity().findViewById(R.id.camera);
+
+        assertFalse(floatAlmostEqual(0.0f, cameraView.getVerticalFOV()));
+        assertFalse(floatAlmostEqual(0.0f, cameraView.getHorizontalFOV()));
+    }
+
+    @Test
+    public void testGetPictureSize() {
+        final CameraView cameraView = (CameraView) rule.getActivity().findViewById(R.id.camera);
+        final Size currentPictureSize = cameraView.getCurrentPictureSize();
+        assertNotNull("Picture size should not be null", currentPictureSize);
+        assertTrue("Width should be > 0", 0 < currentPictureSize.getWidth());
+        assertTrue("Height should be > 0", 0 < currentPictureSize.getHeight());
+    }
+
+
     private static ViewAction waitFor(final long ms) {
         return new AnythingAction("wait") {
             @Override
@@ -406,4 +427,7 @@ public class CameraViewTest {
 
     }
 
+    private boolean floatAlmostEqual(float v1, float v2) {
+        return Math.abs(v1 - v2) < 0.000001f;
+    }
 }

--- a/library/src/main/api14/com/google/android/cameraview/Camera1.java
+++ b/library/src/main/api14/com/google/android/cameraview/Camera1.java
@@ -271,6 +271,16 @@ class Camera1 extends CameraViewImpl {
         }
     }
 
+    @Override
+    float getHorizontalFOV() {
+        return mCameraParameters.getHorizontalViewAngle();
+    }
+
+    @Override
+    float getVerticalFOV() {
+        return mCameraParameters.getVerticalViewAngle();
+    }
+
     /**
      * This rewrites {@link #mCameraId} and {@link #mCameraInfo}.
      */

--- a/library/src/main/api14/com/google/android/cameraview/Camera1.java
+++ b/library/src/main/api14/com/google/android/cameraview/Camera1.java
@@ -71,6 +71,8 @@ class Camera1 extends CameraViewImpl {
 
     private int mDisplayOrientation;
 
+    private Size mCurrentPictureSize = null;
+
     Camera1(Callback callback, PreviewImpl preview) {
         super(callback, preview);
         preview.setCallback(new PreviewImpl.Callback() {
@@ -281,9 +283,8 @@ class Camera1 extends CameraViewImpl {
         return mCameraParameters.getVerticalViewAngle();
     }
 
-    @Override
-    android.util.Size getPictureSize() {
-        return null;
+    Size getCurrentPictureSize() {
+        return mCurrentPictureSize;
     }
 
     /**
@@ -344,6 +345,7 @@ class Camera1 extends CameraViewImpl {
         }
         Size size = chooseOptimalSize(sizes);
         final Camera.Size currentSize = mCameraParameters.getPictureSize();
+        mCurrentPictureSize = new Size(currentSize.width, currentSize.height);
         if (currentSize.width != size.getWidth() || currentSize.height != size.getHeight()) {
             // Largest picture size in this ratio
             final Size pictureSize = mPictureSizes.sizes(mAspectRatio).last();
@@ -359,6 +361,8 @@ class Camera1 extends CameraViewImpl {
             if (mShowingPreview) {
                 mCamera.startPreview();
             }
+
+            mCurrentPictureSize = pictureSize;
         }
     }
 

--- a/library/src/main/api14/com/google/android/cameraview/Camera1.java
+++ b/library/src/main/api14/com/google/android/cameraview/Camera1.java
@@ -281,6 +281,11 @@ class Camera1 extends CameraViewImpl {
         return mCameraParameters.getVerticalViewAngle();
     }
 
+    @Override
+    android.util.Size getPictureSize() {
+        return null;
+    }
+
     /**
      * This rewrites {@link #mCameraId} and {@link #mCameraInfo}.
      */

--- a/library/src/main/api21/com/google/android/cameraview/Camera2.java
+++ b/library/src/main/api21/com/google/android/cameraview/Camera2.java
@@ -358,6 +358,11 @@ class Camera2 extends CameraViewImpl {
     }
 
     @Override
+    android.util.Size getPictureSize() {
+        return null;
+    }
+
+    @Override
     float getVerticalFOV() {
         SizeF sizeF = mCameraCharacteristics.get(CameraCharacteristics.SENSOR_INFO_PHYSICAL_SIZE);
         float[] focalLengths = mCameraCharacteristics.get(

--- a/library/src/main/api21/com/google/android/cameraview/Camera2.java
+++ b/library/src/main/api21/com/google/android/cameraview/Camera2.java
@@ -197,6 +197,8 @@ class Camera2 extends CameraViewImpl {
 
     private int mDisplayOrientation;
 
+    private Size mCurrentPictureSize = null;
+
     Camera2(Callback callback, PreviewImpl preview, Context context) {
         super(callback, preview);
         mCameraManager = (CameraManager) context.getSystemService(Context.CAMERA_SERVICE);
@@ -357,9 +359,8 @@ class Camera2 extends CameraViewImpl {
         return (float) (2 * Math.toDegrees(Math.atan(sizeF.getWidth() / (2 * focalLengths[0]))));
     }
 
-    @Override
-    android.util.Size getPictureSize() {
-        return null;
+    Size getCurrentPictureSize() {
+        return mCurrentPictureSize;
     }
 
     @Override
@@ -475,6 +476,7 @@ class Camera2 extends CameraViewImpl {
         mImageReader = ImageReader.newInstance(largest.getWidth(), largest.getHeight(),
                 ImageFormat.JPEG, /* maxImages */ 2);
         mImageReader.setOnImageAvailableListener(mOnImageAvailableListener, null);
+        mCurrentPictureSize = largest;
     }
 
     /**

--- a/library/src/main/api21/com/google/android/cameraview/Camera2.java
+++ b/library/src/main/api21/com/google/android/cameraview/Camera2.java
@@ -32,6 +32,7 @@ import android.media.Image;
 import android.media.ImageReader;
 import android.support.annotation.NonNull;
 import android.util.Log;
+import android.util.SizeF;
 import android.util.SparseIntArray;
 import android.view.Surface;
 
@@ -345,6 +346,24 @@ class Camera2 extends CameraViewImpl {
     void setDisplayOrientation(int displayOrientation) {
         mDisplayOrientation = displayOrientation;
         mPreview.setDisplayOrientation(mDisplayOrientation);
+    }
+
+    @Override
+    float getHorizontalFOV() {
+        SizeF sizeF = mCameraCharacteristics.get(CameraCharacteristics.SENSOR_INFO_PHYSICAL_SIZE);
+        float[] focalLengths = mCameraCharacteristics.get(
+                CameraCharacteristics.LENS_INFO_AVAILABLE_FOCAL_LENGTHS);
+
+        return (float) (2 * Math.toDegrees(Math.atan(sizeF.getWidth() / (2 * focalLengths[0]))));
+    }
+
+    @Override
+    float getVerticalFOV() {
+        SizeF sizeF = mCameraCharacteristics.get(CameraCharacteristics.SENSOR_INFO_PHYSICAL_SIZE);
+        float[] focalLengths = mCameraCharacteristics.get(
+                CameraCharacteristics.LENS_INFO_AVAILABLE_FOCAL_LENGTHS);
+
+        return (float) (2 * Math.toDegrees(Math.atan(sizeF.getHeight() / (2 * focalLengths[0]))));
     }
 
     /**
@@ -756,5 +775,4 @@ class Camera2 extends CameraViewImpl {
         public abstract void onPrecaptureRequired();
 
     }
-
 }

--- a/library/src/main/base/com/google/android/cameraview/CameraViewImpl.java
+++ b/library/src/main/base/com/google/android/cameraview/CameraViewImpl.java
@@ -69,6 +69,10 @@ abstract class CameraViewImpl {
 
     abstract void setDisplayOrientation(int displayOrientation);
 
+    abstract float getHorizontalFOV();
+
+    abstract float getVerticalFOV();
+
     interface Callback {
 
         void onCameraOpened();

--- a/library/src/main/base/com/google/android/cameraview/CameraViewImpl.java
+++ b/library/src/main/base/com/google/android/cameraview/CameraViewImpl.java
@@ -17,7 +17,6 @@
 package com.google.android.cameraview;
 
 import android.view.View;
-import android.util.Size;
 
 import java.util.Set;
 
@@ -74,7 +73,7 @@ abstract class CameraViewImpl {
 
     abstract float getVerticalFOV();
 
-    abstract Size getPictureSize();
+    abstract Size getCurrentPictureSize();
 
     interface Callback {
 
@@ -85,5 +84,4 @@ abstract class CameraViewImpl {
         void onPictureTaken(byte[] data);
 
     }
-
 }

--- a/library/src/main/base/com/google/android/cameraview/CameraViewImpl.java
+++ b/library/src/main/base/com/google/android/cameraview/CameraViewImpl.java
@@ -17,6 +17,7 @@
 package com.google.android.cameraview;
 
 import android.view.View;
+import android.util.Size;
 
 import java.util.Set;
 
@@ -72,6 +73,8 @@ abstract class CameraViewImpl {
     abstract float getHorizontalFOV();
 
     abstract float getVerticalFOV();
+
+    abstract Size getPictureSize();
 
     interface Callback {
 

--- a/library/src/main/java/com/google/android/cameraview/CameraView.java
+++ b/library/src/main/java/com/google/android/cameraview/CameraView.java
@@ -399,12 +399,28 @@ public class CameraView extends FrameLayout {
         return mImpl.getFlash();
     }
 
+    /**
+     * Get's equivalent of {@link android.hardware.Camera.Parameters#getHorizontalViewAngle()}
+     * @return angle in degrees
+     */
     public float getHorizontalFOV() {
         return mImpl.getHorizontalFOV();
     }
 
+    /**
+     * Get equivalent of {@link android.hardware.Camera.Parameters#getVerticalViewAngle()}
+     * @return angle in degrees
+     */
     public float getVerticalFOV() {
         return mImpl.getVerticalFOV();
+    }
+
+    /**
+     * Get current picture size
+     * @return Size of (width, height); null if camera is not yet initialized
+     */
+    public Size getCurrentPictureSize() {
+        return mImpl.getCurrentPictureSize();
     }
 
     /**

--- a/library/src/main/java/com/google/android/cameraview/CameraView.java
+++ b/library/src/main/java/com/google/android/cameraview/CameraView.java
@@ -399,6 +399,14 @@ public class CameraView extends FrameLayout {
         return mImpl.getFlash();
     }
 
+    public float getHorizontalFOV() {
+        return mImpl.getHorizontalFOV();
+    }
+
+    public float getVerticalFOV() {
+        return mImpl.getVerticalFOV();
+    }
+
     /**
      * Take a picture. The result will be returned to
      * {@link Callback#onPictureTaken(CameraView, byte[])}.


### PR DESCRIPTION
This PR adds a few hooks to expose the following parameters
- Horizontal and vertical viewing angel
- Current picture size 

Both will be available after `CameraView.start()`