### PR TITLE
Fixing RuntimeException when calling CameraView.stop()

### DIFF
--- a/library/src/main/api14/com/google/android/cameraview/Camera1.java
+++ b/library/src/main/api14/com/google/android/cameraview/Camera1.java
@@ -243,8 +243,11 @@ class Camera1 extends CameraViewImpl {
                 public void onPictureTaken(byte[] data, Camera camera) {
                     isPictureCaptureInProgress.set(false);
                     mCallback.onPictureTaken(data);
-                    camera.cancelAutoFocus();
-                    camera.startPreview();
+                    //Check if camera still previewing 
+                    if(mShowingPreview){
+                        camera.cancelAutoFocus();
+                        camera.startPreview();
+                    }
                 }
             });
         }


### PR DESCRIPTION
When `CameraView.stop()` get called by a `Callback.onPictureTaken` we get an exception `RuntimeException: Camera is being used after Camera.release() was called`