### PR TITLE
Fix crash when click on rotate camera icon + take pic fast

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.0'
+        classpath 'com.android.tools.build:gradle:2.3.2'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/demo/src/main/java/com/google/android/cameraview/demo/MainActivity.java
+++ b/demo/src/main/java/com/google/android/cameraview/demo/MainActivity.java
@@ -102,6 +102,7 @@ public class MainActivity extends AppCompatActivity implements
             }
         }
     };
+    private FloatingActionButton mFab;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -111,10 +112,7 @@ public class MainActivity extends AppCompatActivity implements
         if (mCameraView != null) {
             mCameraView.addCallback(mCallback);
         }
-        FloatingActionButton fab = (FloatingActionButton) findViewById(R.id.take_picture);
-        if (fab != null) {
-            fab.setOnClickListener(mOnClickListener);
-        }
+        mFab = (FloatingActionButton) findViewById(R.id.take_picture);
         Toolbar toolbar = (Toolbar) findViewById(R.id.toolbar);
         setSupportActionBar(toolbar);
         ActionBar actionBar = getSupportActionBar();
@@ -238,6 +236,14 @@ public class MainActivity extends AppCompatActivity implements
             = new CameraView.Callback() {
 
         @Override
+        public void onCameraConfigured(CameraView cameraView) {
+            super.onCameraConfigured(cameraView);
+            if (mFab != null) {
+                mFab.setOnClickListener(mOnClickListener);
+            }
+        }
+
+        @Override
         public void onCameraOpened(CameraView cameraView) {
             Log.d(TAG, "onCameraOpened");
         }
@@ -245,6 +251,9 @@ public class MainActivity extends AppCompatActivity implements
         @Override
         public void onCameraClosed(CameraView cameraView) {
             Log.d(TAG, "onCameraClosed");
+            if (mFab != null) {
+                mFab.setOnClickListener(null);
+            }
         }
 
         @Override

--- a/library/src/main/api14/com/google/android/cameraview/Camera1.java
+++ b/library/src/main/api14/com/google/android/cameraview/Camera1.java
@@ -307,6 +307,7 @@ class Camera1 extends CameraViewImpl {
         adjustCameraParameters();
         mCamera.setDisplayOrientation(calcDisplayOrientation(mDisplayOrientation));
         mCallback.onCameraOpened();
+        mCallback.onCameraConfigured();
     }
 
     private AspectRatio chooseAspectRatio() {

--- a/library/src/main/api21/com/google/android/cameraview/Camera2.java
+++ b/library/src/main/api21/com/google/android/cameraview/Camera2.java
@@ -104,6 +104,7 @@ class Camera2 extends CameraViewImpl {
             mCaptureSession = session;
             updateAutoFocus();
             updateFlash();
+            mCallback.onCameraConfigured();
             try {
                 mCaptureSession.setRepeatingRequest(mPreviewRequestBuilder.build(),
                         mCaptureCallback, null);

--- a/library/src/main/base/com/google/android/cameraview/CameraViewImpl.java
+++ b/library/src/main/base/com/google/android/cameraview/CameraViewImpl.java
@@ -75,6 +75,8 @@ abstract class CameraViewImpl {
 
         void onCameraClosed();
 
+        void onCameraConfigured();
+
         void onPictureTaken(byte[] data);
 
     }

--- a/library/src/main/java/com/google/android/cameraview/CameraView.java
+++ b/library/src/main/java/com/google/android/cameraview/CameraView.java
@@ -443,6 +443,13 @@ public class CameraView extends FrameLayout {
         }
 
         @Override
+        public void onCameraConfigured() {
+            for (Callback callback : mCallbacks) {
+                callback.onCameraConfigured(CameraView.this);
+            }
+        }
+
+        @Override
         public void onPictureTaken(byte[] data) {
             for (Callback callback : mCallbacks) {
                 callback.onPictureTaken(CameraView.this, data);
@@ -534,6 +541,15 @@ public class CameraView extends FrameLayout {
          * @param data       JPEG data.
          */
         public void onPictureTaken(CameraView cameraView, byte[] data) {
+        }
+
+        /**
+         * Called when camera is configured and session is not null.
+         *
+         * @param cameraView The associated {@link CameraView}.
+         */
+        public void onCameraConfigured(CameraView cameraView) {
+
         }
     }
 

--- a/library/src/main/java/com/google/android/cameraview/CameraView.java
+++ b/library/src/main/java/com/google/android/cameraview/CameraView.java
@@ -544,7 +544,7 @@ public class CameraView extends FrameLayout {
         }
 
         /**
-         * Called when camera is configured and session is not null.
+         * Called when camera is configured ready to take pictures.
          *
          * @param cameraView The associated {@link CameraView}.
          */


### PR DESCRIPTION
App crashes because session is null but user tries to take pic ==> NPE

java.lang.NullPointerException: Attempt to invoke virtual method 'int android.hardware.camera2.CameraCaptureSession.capture(android.hardware.camera2.CaptureRequest, android.hardware.camera2.CameraCaptureSession$CaptureCallback, android.os.Handler)' on a null object reference
                                                                           at com.google.android.cameraview.Camera2.lockFocus(Camera2.java:587)
                                                                           at com.google.android.cameraview.Camera2.takePicture(Camera2.java:338)
                                                                           at com.google.android.cameraview.CameraView.takePicture(CameraView.java:407)