### PR TITLE
Fix app:aspectRatio not working at Camera2

### DIFF
--- a/library/src/main/api21/com/google/android/cameraview/Camera2.java
+++ b/library/src/main/api21/com/google/android/cameraview/Camera2.java
@@ -263,11 +263,19 @@ class Camera2 extends CameraViewImpl {
 
     @Override
     boolean setAspectRatio(AspectRatio ratio) {
-        if (ratio == null || ratio.equals(mAspectRatio) ||
-                !mPreviewSizes.ratios().contains(ratio)) {
+        if (ratio == null || ratio.equals(mAspectRatio)) {
             // TODO: Better error handling
             return false;
         }
+        if (!mPreviewSizes.ratios().contains(ratio)) {
+            if (mPreviewSizes.ratios().size() <= 0) {
+                // may be initialized from layout xml
+                mAspectRatio = ratio;
+                return true;
+            }
+            return false;
+        }
+
         mAspectRatio = ratio;
         prepareImageReader();
         if (mCaptureSession != null) {


### PR DESCRIPTION
When device has Camera2 API (whether Camera2 class expected to successfully initialized or not), `app:aspectRatio` value is passed following `CameraView(Context, AttributeSet, int)`, `CameraView#setAspectRatio(AspectRatio)` and `Camera2#setAspectRatio(AspectRatio)`.
In [`Camera2#setAspectRatio(AspectRatio)`](https://github.com/google/cameraview/blob/master/library/src/main/api21/com/google/android/cameraview/Camera2.java#L265), checking ratio is exists in `mPreviewSizes` but it is initializing when `Camera2#start()`.
Therefore `mPreviewSizes` has no value, so reaching `return false` and aspect ratio keeps 4:3 (default value).
