### PR TITLE
Nullpointer when setting picture size parameter in Camera1

### DIFF
--- a/library/src/main/api14/com/google/android/cameraview/Camera1.java
+++ b/library/src/main/api14/com/google/android/cameraview/Camera1.java
@@ -328,12 +328,19 @@ class Camera1 extends CameraViewImpl {
         }
         Size size = chooseOptimalSize(sizes);
 
-        // Always re-apply camera parameters
-        // Largest picture size in this ratio
-        final Size pictureSize = mPictureSizes.sizes(mAspectRatio).last();
+        final Size pictureSize;
+        if (mPictureSizes.sizes(mAspectRatio) == null) {
+            pictureSize = size;
+        } else {
+            // Largest picture size in this ratio
+            pictureSize = mPictureSizes.sizes(mAspectRatio).last();
+        }
+
         if (mShowingPreview) {
             mCamera.stopPreview();
         }
+
+        // Always re-apply camera parameters
         mCameraParameters.setPreviewSize(size.getWidth(), size.getHeight());
         mCameraParameters.setPictureSize(pictureSize.getWidth(), pictureSize.getHeight());
         mCameraParameters.setRotation(calcCameraRotation(mDisplayOrientation));


### PR DESCRIPTION
The camera crashes in some devices running Android 5.1. This is the issue to track it: https://github.com/google/cameraview/issues/72

```
Caused by java.lang.NullPointerException: Attempt to invoke interface method 'java.lang.Object java.util.SortedSet.last()' on a null object reference
       at com.google.android.cameraview.Camera1.adjustCameraParameters(Camera1.java:349)
       at com.google.android.cameraview.Camera1.setAspectRatio(Camera1.java:168)
       at com.google.android.cameraview.CameraView.setAspectRatio(CameraView.java:335)
```

The reason is that we try to access the last `PictureSizes` item for an `AspectRatio` and there is no such size for that aspect ratio.

In those case we should be defaulting to the `PreviewSizes`