### PR TITLE
Add a getter to get the camera orientation relative to the devices native orientation

### DIFF
--- a/library/src/main/api14/com/google/android/cameraview/Camera1.java
+++ b/library/src/main/api14/com/google/android/cameraview/Camera1.java
@@ -251,6 +251,11 @@ class Camera1 extends CameraViewImpl {
     }
 
     @Override
+    int getCameraOrientation() {
+        return mCameraInfo.orientation;
+    }
+
+    @Override
     void setDisplayOrientation(int displayOrientation) {
         if (mDisplayOrientation == displayOrientation) {
             return;

--- a/library/src/main/api21/com/google/android/cameraview/Camera2.java
+++ b/library/src/main/api21/com/google/android/cameraview/Camera2.java
@@ -193,6 +193,8 @@ class Camera2 extends CameraViewImpl {
     private boolean mAutoFocus;
 
     private int mFlash;
+    
+    private int mCameraOrientation;
 
     private int mDisplayOrientation;
 
@@ -342,6 +344,11 @@ class Camera2 extends CameraViewImpl {
     }
 
     @Override
+    int getCameraOrientation() {
+        return mCameraOrientation;
+    }
+
+    @Override
     void setDisplayOrientation(int displayOrientation) {
         mDisplayOrientation = displayOrientation;
         mPreview.setDisplayOrientation(mDisplayOrientation);
@@ -407,8 +414,8 @@ class Camera2 extends CameraViewImpl {
 
     /**
      * <p>Collects some information from {@link #mCameraCharacteristics}.</p>
-     * <p>This rewrites {@link #mPreviewSizes}, {@link #mPictureSizes}, and optionally,
-     * {@link #mAspectRatio}.</p>
+     * <p>This rewrites {@link #mPreviewSizes}, {@link #mPictureSizes},
+     * {@link #mCameraOrientation}, and optionally, {@link #mAspectRatio}.</p>
      */
     private void collectCameraInfo() {
         StreamConfigurationMap map = mCameraCharacteristics.get(
@@ -435,6 +442,8 @@ class Camera2 extends CameraViewImpl {
         if (!mPreviewSizes.ratios().contains(mAspectRatio)) {
             mAspectRatio = mPreviewSizes.ratios().iterator().next();
         }
+
+        mCameraOrientation = mCameraCharacteristics.get(CameraCharacteristics.SENSOR_ORIENTATION);
     }
 
     protected void collectPictureSizes(SizeMap sizes, StreamConfigurationMap map) {

--- a/library/src/main/base/com/google/android/cameraview/CameraViewImpl.java
+++ b/library/src/main/base/com/google/android/cameraview/CameraViewImpl.java
@@ -67,6 +67,8 @@ abstract class CameraViewImpl {
 
     abstract void takePicture();
 
+    abstract int getCameraOrientation();
+
     abstract void setDisplayOrientation(int displayOrientation);
 
     interface Callback {

--- a/library/src/main/java/com/google/android/cameraview/CameraView.java
+++ b/library/src/main/java/com/google/android/cameraview/CameraView.java
@@ -400,6 +400,15 @@ public class CameraView extends FrameLayout {
     }
 
     /**
+     * Gets the camera orientation relative to the devices native orientation.
+     *
+     * @return The orientation of the camera.
+     */
+    public int getCameraOrientation() {
+        return mImpl.getCameraOrientation();
+    }
+
+    /**
      * Take a picture. The result will be returned to
      * {@link Callback#onPictureTaken(CameraView, byte[])}.
      */


### PR DESCRIPTION
This is useful for when you are using the image data from the `onFramePreview` callback and need to correct the image rotation before sending it through to something like the Mobile Vision SDK.

The lack of this was causing libraries to make assumptions about the camera orientation which causes bugs like this: https://github.com/react-native-community/react-native-camera/issues/1714